### PR TITLE
Clear handlers and add StaticFileModule in challenge directory

### DIFF
--- a/LetsEncrypt.SiteExtension.Core/CertificateManager.cs
+++ b/LetsEncrypt.SiteExtension.Core/CertificateManager.cs
@@ -36,7 +36,8 @@ namespace LetsEncrypt.SiteExtension.Core
       <add name=""ACMEStaticFile"" path=""*"" verb=""*"" modules=""StaticFileModule"" resourceType=""Either"" requireAccess=""Read"" />
     </handlers>
     <staticContent>
-      <mimeMap fileExtension=""."" mimeType=""text/json"" />
+      <remove fileExtension=""."" />
+      <mimeMap fileExtension=""."" mimeType=""text/plain"" />
     </staticContent>
   </system.webServer>
 </configuration>";

--- a/LetsEncrypt.SiteExtension.Core/CertificateManager.cs
+++ b/LetsEncrypt.SiteExtension.Core/CertificateManager.cs
@@ -28,14 +28,18 @@ namespace LetsEncrypt.SiteExtension.Core
         static string configPath = "";
         private static string BaseURI;
         static AppSettingsAuthConfig settings = new AppSettingsAuthConfig();
-        const string webConfig = @"<?xml version = ""1.0"" encoding=""UTF-8""?>
- <configuration>
-     <system.webServer>
-         <staticContent>
-             <mimeMap fileExtension = ""."" mimeType=""text/json"" />
-         </staticContent>
-     </system.webServer>
- </configuration>";
+        const string webConfig = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <clear />
+      <add name=""ACMEStaticFile"" path=""*"" verb=""*"" modules=""StaticFileModule"" resourceType=""Either"" requireAccess=""Read"" />
+    </handlers>
+    <staticContent>
+      <mimeMap fileExtension=""."" mimeType=""text/json"" />
+    </staticContent>
+  </system.webServer>
+</configuration>";
         private static WebSiteManagementClient webSiteClient;
         private static WebSiteManagementClient serverFarmClient;
 


### PR DESCRIPTION
When using ASP.NET Core 1.0 you typically register a HttpPlatformHandler in your base `web.config` which then forwards all requests to ASP.NET Core 1.0 is (still) hosted in dnx. IIRC this is also the case for all other "backend servers" like node or php, so this might also fix #27.

The problem with is that requests to `.well-known/acme-challenges` have to be handled in the backend code, which can be a bit hairy. For example in ASP.NET Core 1.0 RC1, the static file middleware will, by default, not serve files without extension.

My solution was to only use the StaticFileModule in `.well-known/acme-challenges` which worked very well. In my view, this should be the default behavior.

I think there's another potential issue in the `mimeMap`. Since it misses `<remove fileExtension="." />` it can lead to nasty "duplicate keys" errors in IIS. Also it should be save to serve the files as "text/plain".