### PR TITLE
Update web.config to allow anonymous access

### DIFF
--- a/LetsEncrypt.SiteExtension.Core/CertificateManager.cs
+++ b/LetsEncrypt.SiteExtension.Core/CertificateManager.cs
@@ -40,6 +40,11 @@ namespace LetsEncrypt.SiteExtension.Core
       <mimeMap fileExtension=""."" mimeType=""text/plain"" />
     </staticContent>
   </system.webServer>
+  <system.web>
+    <authorization>
+      <allow users=""?""/>
+    </authorization>
+  </system.web>
 </configuration>";
         private static WebSiteManagementClient webSiteClient;
 


### PR DESCRIPTION
I recently installed the extension for my Azure WebSite. Let's Encrypt was unable to access the necessary files unless I added this section to the web.config in the acme-challenge folder. This may be because my site is built in ASP.NET WebForms. Regardless, this should permit access to the acme-challenge files as desired.