### PR TITLE
Allow multiple WebJobs to run on the same storage account

### DIFF
--- a/LetsEncrypt.SiteExtension.WebJob/Functions.cs
+++ b/LetsEncrypt.SiteExtension.WebJob/Functions.cs
@@ -37,10 +37,11 @@ namespace LetsEncrypt.SiteExtension
         public static void SetupHostNameAndCertificate([TimerTrigger(typeof(MonthlySchedule), RunOnStartup = true)] TimerInfo timerInfo, [Blob("letsencrypt/firstrun.job")] string input, [Blob("letsencrypt/firstrun.job")] out string output)
         {
             Console.WriteLine("Starting setup hostname and certificate");
-            if (string.IsNullOrEmpty(input))
+            string websiteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+            if (string.IsNullOrEmpty(input) || !input.Contains(websiteName))
             {
                 new CertificateManager().SetupHostnameAndCertificate();
-                output = DateTime.UtcNow.ToString();
+                output = string.IsNullOrEmpty(input) ? websiteName : input + '|' + websiteName;
             }
             else
             {

--- a/LetsEncrypt.SiteExtension.WebJob/Program.cs
+++ b/LetsEncrypt.SiteExtension.WebJob/Program.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
+using System.Configuration;
 
 namespace LetsEncrypt.SiteExtension.WebJob
 {
@@ -16,6 +17,8 @@ namespace LetsEncrypt.SiteExtension.WebJob
         {
             var config = new JobHostConfiguration();
             config.UseTimers();
+            config.HostId = "letsencrypt_" + Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+
             var host = new JobHost(config);
             host.RunAndBlock();
         }


### PR DESCRIPTION
Avoid certificates not being renewed if instances running the extension's web job are set up to use the same storage account.