### PR TITLE
Set authorization of acme-challenge folder to "all users"

### DIFF
--- a/LetsEncrypt.SiteExtension.Core/Services/BaseAuthorizationChallengeProvider.cs
+++ b/LetsEncrypt.SiteExtension.Core/Services/BaseAuthorizationChallengeProvider.cs
@@ -29,7 +29,7 @@ namespace LetsEncrypt.Azure.Core.Services
   </system.webServer>
   <system.web>
     <authorization>
-      <allow users=""?""/>
+      <allow users=""*""/>
     </authorization>
   </system.web>
 </configuration>";


### PR DESCRIPTION
When using the extension on a site with Forms Authentication enabled, the `web.config` generated in the `acme-challenge` folder prevents access to the files in that folder; requests are redirected to the site's login page. This results in a "The Lets Encrypt ACME server was probably unable to reach [site]/.well-known/acme-challenge/[file]" error during a certificate request.

This PR sets the authorization for that folder to `<allow users="*"/>` (i.e., "all users", rather than "anonymous users"); with this setting, Forms Authentication no longer redirects to the login page. 