### PR TITLE
Allowed .NET to use TLS 1.1 and 1.2

### DIFF
--- a/LetsEncrypt-SiteExtension/Global.asax.cs
+++ b/LetsEncrypt-SiteExtension/Global.asax.cs
@@ -10,6 +10,8 @@ using System.Web.Http;
 
 namespace LetsEncrypt.SiteExtension
 {
+    using System.Net;
+
     public class Global : HttpApplication
     {
         void Application_Start(object sender, EventArgs e)
@@ -18,7 +20,8 @@ namespace LetsEncrypt.SiteExtension
             AreaRegistration.RegisterAllAreas();
             GlobalConfiguration.Configure(WebApiConfig.Register);
             RouteConfig.RegisterRoutes(RouteTable.Routes);
-           
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls11;
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
         }
     }
 }


### PR DESCRIPTION
Now it is possible to select TLS version for Azure web apps. Today, when I was trying manual renew of a certificate, I was not able to do it, as my web app uses only TLS 1.2 connection - so, I was obliged to push TLS to 1.0, renew certificate manually and push it back to 1.2