### PR TITLE
Return an empty list from SettingsStore.Load() in case of an empty file or invalid content

### DIFF
--- a/LetsEncrypt.SiteExtension.Core/SettingsStore.cs
+++ b/LetsEncrypt.SiteExtension.Core/SettingsStore.cs
@@ -44,13 +44,27 @@ namespace LetsEncrypt.Azure.Core
 
         public List<SettingEntry> Load()
         {
-            if (File.Exists(_settingsFilePath))
+            var empty = new List<SettingEntry>();
+            if (!File.Exists(_settingsFilePath))
             {
-                return JsonConvert.DeserializeObject<List<SettingEntry>>(File.ReadAllText(_settingsFilePath));
+                return empty;
             }
-            else
+            
+            var text = File.ReadAllText(_settingsFilePath);
+            if (String.IsNullOrWhiteSpace(text))
             {
-                return new List<SettingEntry>();
+                return empty;
+            }
+
+            try
+            {
+                return JsonConvert.DeserializeObject<List<SettingEntry>>(text);
+            }
+            catch(Exception ex)
+            {
+                // TODO: Probably some proper logging would be good here
+                Console.Error.WriteLine(ex);
+                return empty;
             }
         }
 


### PR DESCRIPTION
Because in case of an existing empty file, `JsonConvert.DeserializeObject<T>(...)` returns null.

This method is used e.g. in `HomeController.Install()`:
https://github.com/sjkp/letsencrypt-siteextension/blob/f2e8f392cd7706d3f71bc5d1fcbde1e69d120e91/LetsEncrypt-SiteExtension/Controllers/HomeController.cs#L173

So, `.FirstOrDefault()` is called on null here and an exception is thrown.

The pull request just returns an empty list in case something goes wrong instead of just showing an exception with a stacktrace so that the user can set settings.