### PR TITLE
Fix minor misspelling

### DIFF
--- a/LetsEncrypt-SiteExtension/Views/Home/Install.cshtml
+++ b/LetsEncrypt-SiteExtension/Views/Home/Install.cshtml
@@ -9,7 +9,7 @@
     Select the custom domain names for which you want to request a Let's Encrypt SSL certificate, and provide your email, in order to create an account with Let's Encrypt. 
 </p>
 <p>
-    Note that you can only request 5 certifcates per week for the same domain, so if you are running tests, make sure to use the staging enviroment, where you have unlimited.
+    Note that you can only request 5 certificates per week for the same domain, so if you are running tests, make sure to use the staging enviroment, where you have unlimited.
 </p>
 @using (Html.BeginForm())
 {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/mdg0e31rp0qdu16m/branch/master?svg=true
 )](https://ci.appveyor.com/project/sjkp/letsencrypt-siteextension) [![Build status](https://dockerbuildbadges.quelltext.eu/status.svg?organization=sjkp&repository=letsencrypt-azure)](https://hub.docker.com/r/sjkp/letsencrypt-azure/)
 
-This Azure Web App Site Extension enables easy installation and configuration of [Let's Encrypt](https://letsencrypt.org/) issued SSL certifcates for you custom domain names. 
+This Azure Web App Site Extension enables easy installation and configuration of [Let's Encrypt](https://letsencrypt.org/) issued SSL certificates for you custom domain names. 
 
 The site extension requires that you have configured a DNS entry for you custom domain to point to Azure Web App. 
 


### PR DESCRIPTION
I was setting up Let's Encrypt on a web app and I just happened to notice the misspelling of "certificates" - thought I'd send this your way. Thanks for a great extension - it has been very helpful!