### PR TITLE
Make webroot path configurable for core app

### DIFF
--- a/LetsEncrypt-SiteExtension/Models/AuthenticationModel.cs
+++ b/LetsEncrypt-SiteExtension/Models/AuthenticationModel.cs
@@ -87,6 +87,11 @@ namespace LetsEncrypt.SiteExtension.Models
             get;set;
         }
 
+        public string WebRootPath
+        {
+            get; set;
+        }
+
         public static explicit operator AuthenticationModel(AppSettingsAuthConfig config)
         {
             return new AuthenticationModel()
@@ -103,7 +108,8 @@ namespace LetsEncrypt.SiteExtension.Models
                 AzureWebSitesDefaultDomainName = config.AzureWebSitesDefaultDomainName,
                 ManagementEndpoint = config.ManagementEndpoint,
                 TokenAudience = config.TokenAudience,
-                SiteSlotName = config.SiteSlotName
+                SiteSlotName = config.SiteSlotName,
+                WebRootPath = config.WebRootPath
             };
         }
     }

--- a/LetsEncrypt.SiteExtension.Core/AppSettingsAuthConfig.cs
+++ b/LetsEncrypt.SiteExtension.Core/AppSettingsAuthConfig.cs
@@ -21,6 +21,7 @@ namespace LetsEncrypt.Azure.Core.Models
         public const string acmeBaseUriKey = "letsencrypt:AcmeBaseUri";
         public const string siteSlotNameKey = "letsencrypt:SiteSlot";
         public const string webAppNameKey = "WEBSITE_SITE_NAME";
+        public const string webRootPath = "letsencrypt:WebRootPath";
         public const string servicePlanResourceGroupNameKey = "letsencrypt:ServicePlanResourceGroupName";
         public const string rsaKeyLengthKey = "letsencrypt:RSAKeyLength";
         private readonly WebAppEnviromentVariables environemntVariables;
@@ -102,6 +103,14 @@ namespace LetsEncrypt.Azure.Core.Models
             get
             {
                 return ConfigurationManager.AppSettings[webAppNameKey]; 
+            }
+        }
+
+        public string WebRootPath
+        {
+            get
+            {
+                return ConfigurationManager.AppSettings[webRootPath];
             }
         }
 

--- a/LetsEncrypt.SiteExtension.Core/IAzureEnvironment.cs
+++ b/LetsEncrypt.SiteExtension.Core/IAzureEnvironment.cs
@@ -31,7 +31,7 @@ namespace LetsEncrypt.Azure.Core.Models
 
         string AzureWebSitesDefaultDomainName { get; }
 
-      
+        string WebRootPath { get; }
     }
 
     public interface IAzureDnsEnvironment : IAzureEnvironment
@@ -142,10 +142,11 @@ namespace LetsEncrypt.Azure.Core.Models
     /// </summary>
     public class AzureWebAppEnvironment : AzureEnvironment, IAzureWebAppEnvironment
     {
-        public AzureWebAppEnvironment(string tenant, Guid subscription, Guid clientId, string clientSecret, string resourceGroup, string webAppName, string servicePlanResourceGroupName = null, string siteSlotName = null)
+        public AzureWebAppEnvironment(string tenant, Guid subscription, Guid clientId, string clientSecret, string resourceGroup, string webAppName, string servicePlanResourceGroupName = null, string siteSlotName = null, string webrootPath = null)
             : base(tenant, subscription, clientId, clientSecret, resourceGroup)
         {          
             this.WebAppName = webAppName;
+            this.WebRootPath = webrootPath;
             this.ServicePlanResourceGroupName = string.IsNullOrEmpty(servicePlanResourceGroupName) ? resourceGroup : servicePlanResourceGroupName;
             this.SiteSlotName = siteSlotName;            
         }
@@ -190,6 +191,14 @@ namespace LetsEncrypt.Azure.Core.Models
         /// </summary>
         [Required]
         public string WebAppName
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// The path to the web root.
+        /// </summary>
+        public string WebRootPath
         {
             get; set;
         }

--- a/LetsEncrypt.SiteExtension.Core/Services/LocalFileSystemAuthorizationChallengeProvider.cs
+++ b/LetsEncrypt.SiteExtension.Core/Services/LocalFileSystemAuthorizationChallengeProvider.cs
@@ -30,9 +30,9 @@ namespace LetsEncrypt.Azure.Core.Services
 
        
 
-        private static string WebRootPath()
+        private string WebRootPath()
         {
-            return ConfigurationManager.AppSettings["letsencrypt:WebRootPath"] ?? Path.Combine(Environment.ExpandEnvironmentVariables("%HOME%"), "site", "wwwroot");
+            return azureEnvironment.WebRootPath ?? Path.Combine(Environment.ExpandEnvironmentVariables("%HOME%"), "site", "wwwroot");
         }
 
         private string ChallengeDirectory
@@ -84,7 +84,7 @@ namespace LetsEncrypt.Azure.Core.Services
             return Task.CompletedTask;
         }
 
-        private static string GetAnswerPath(HttpChallenge httpChallenge)
+        private string GetAnswerPath(HttpChallenge httpChallenge)
         {
             // We need to strip off any leading '/' in the path
             var filePath = httpChallenge.FilePath;


### PR DESCRIPTION
Include the WebRootPath setting in to IAzureWebAppEnvironment so it can be used to determine where the application is located when using the core API.

Fixes #241