### PR TITLE
Update App Service Managed Certificates Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Azure Web App Site Extension enables easy installation and configuration of
 
 The site extension requires that you have configured a DNS entry for your custom domain to point to Azure Web App. 
 
-November 2019 - Microsoft finally acknowledge that maybe it is in due time that they add first level support for free SSL certificates, see this announcement about [App Service Managed Certificates](https://azure.microsoft.com/en-us/updates/secure-your-custom-domains-at-no-cost-with-app-service-managed-certificates-preview/), be aware that it is in preview and currently **doesn't support** the apex/naked domain. 
+May 2021 - Microsoft made [App Service Managed Certificates](https://azure.microsoft.com/en-us/updates/app-service-managed-certificates-now-generally-available/) generally available, which provides support for free SSL certificates for Apex/naked domains and subdomains.
 
 ## How to install
 https://github.com/sjkp/letsencrypt-siteextension/wiki/How-to-install


### PR DESCRIPTION
I noticed the readme was slightly outdated regarding to the App Service Managed Certificates, so this includes a link to the latest blog post which indicates that it is generally available and has support for both type domains (Root/Apex & Sub).